### PR TITLE
Eliminate unnecessary uses of `rethrow(e)`

### DIFF
--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -311,6 +311,7 @@ struct UseOfStaticThreads <: ViolationLintRule end
 struct LogStatementsMustBeSafe <: FatalLintRule end
 struct AssertionStatementsMustBeSafe <: ViolationLintRule end
 struct NonFrontShapeAPIUsageRule <: FatalLintRule end
+struct RethrowAndExceptionRule <: ViolationLintRule end
 
 const all_extended_rule_types = Ref{Vector{DataType}}(
     vcat(
@@ -659,3 +660,16 @@ function check(t::AssertionStatementsMustBeSafe, x::EXPR, markers::Dict{Symbol,S
     end
 end
 
+function check(t::RethrowAndExceptionRule, x::EXPR)
+    generic_check(
+        t,
+        x,
+        "try
+            hole_variable_star
+        catch hole_variableA
+            hole_variable_star
+            rethrow(hole_variableA)
+            hole_variable_star
+        end",
+        "Change `rethrow(e)` into `rethrow()`.")
+end

--- a/test/exceptions_tests.jl
+++ b/test/exceptions_tests.jl
@@ -1,0 +1,53 @@
+@testset "Exception-related rules" begin
+    @testset "Eliminate unnecessary rethrow(e)" begin
+        source = raw"""
+            function f()
+                try
+                    print("Hello")
+                catch e
+                    print("World")
+                    # error handling code / error logging
+                    rethrow(e)
+                end
+            end
+            """
+        @test count_lint_errors(source) == 1
+        @test lint_test(source, "Line 2, column 5: Change `rethrow(e)` into `rethrow()`.")
+    end
+
+    @testset "Acceptable rethrow 1" begin
+        source = raw"""
+            function f()
+                try
+                    print("Hello")
+                catch e
+                    print("World")
+                    e2 = Exception("Error")
+                    # error handling code / error logging
+                    rethrow(e2)
+                end
+            end
+            """
+        # @test count_lint_errors(source) == 0
+        @test lint_test(source, "Lined 2, column 5: Change `rethrow(e)` into `rethrow()`.")
+
+    end
+
+    @testset "Acceptable rethrow 2" begin
+        source = raw"""
+            function f()
+                try
+                    print("Hello")
+                catch e
+                    print("World")
+                    e2 = Exception("Error")
+                    # error handling code / error logging
+                    rethrow()
+                end
+            end
+            """
+        # @test count_lint_errors(source) == 0
+        @test lint_test(source, "Lined 2, column 5: Change `rethrow(e)` into `rethrow()`.")
+
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,8 @@ using ReLint: convert_offset_to_line_from_lines, check_all
 
 include(joinpath(@__DIR__, "common.jl"))
 
+
+include(joinpath(@__DIR__, "exceptions_tests.jl"))
 include(joinpath(@__DIR__, "safe_logging_tests.jl"))
 include(joinpath(@__DIR__, "lint_context_tests.jl"))
 include(joinpath(@__DIR__, "rai_rules_tests.jl"))


### PR DESCRIPTION
Draft to address: https://relationalai.atlassian.net/browse/RAI-7999
Unfortunately, we are not there yet. 