### PR TITLE
Fix bug with pre-commit file

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -644,13 +644,14 @@ function generate_report(
         io_violations = IOBuffer()
         io_recommendations = IOBuffer()
 
-
-        context = LintContext(rules_to_run)
+        context = nothing
         if !isempty(pre_commit_file)
-            context.regex_exclusions = extract_file_exclusions_from_precommit_file(pre_commit_file)
+            context = LintContext(
+                rules_to_run,
+                extract_file_exclusions_from_precommit_file(pre_commit_file))
+        else
+            context = LintContext(rules_to_run)
         end
-
-        # @info "Will check rules:" rules_to_run
 
         # RUN LINT!!!
         for filename in julia_filenames


### PR DESCRIPTION
Fix bug:

```
ERROR: setfield!: immutable struct of type LintContext cannot be changed
Stacktrace:
 [1] setproperty!(x::ReLint.LintContext, f::Symbol, v::Vector{Any})
   @ Base ./Base.jl:41
 [2] (::ReLint.var"#46#49"{String, String, String, Base.PipeEndpoint, Vector{DataType}, String, ReLint.LintResult})(output_io::IOStream)
   @ ReLint ~/work/raicode/raicode/ReLint.jl/src/interface.jl:650
 [3] open(::ReLint.var"#46#49"{String, String, String, Base.PipeEndpoint, Vector{DataType}, String, ReLint.LintResult}, ::String, ::Vararg{String}; kwargs::@Kwargs{})
   @ Base ./io.jl:396
 [4] open
   @ ./io.jl:[39](https://github.com/RelationalAI/raicode/actions/runs/14738734240/job/41371240972?pr=23858#step:8:40)3 [inlined]
 [5] generate_report(filenames::Vector{String}, output_filename::String; json_output::Base.PipeEndpoint, json_filename::String, github_repository::String, branch_name::String, file_prefix_to_remove::String, analyze_all_file_found_locally::Bool, stream_workflowcommand::Base.PipeEndpoint, rules_to_run::Vector{DataType}, pre_commit_file::String)
   @ ReLint ~/work/raicode/raicode/ReLint.jl/src/interface.jl:628
 [6] top-level scope
   @ none:3
```