### PR TITLE
Allow Shape in FrontCompiler package

### DIFF
--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -603,6 +603,7 @@ function check(t::NonFrontShapeAPIUsageRule, x::EXPR, markers::Dict{Symbol,Strin
     haskey(markers, :filename) || return
     # In the front-end and in FFI, we are allowed to refer to `Shape`
     contains(markers[:filename], "src/FrontCompiler") && return
+    contains(markers[:filename], "packages/RAI_FrontCompiler") && return
     contains(markers[:filename], "src/FFI") && return
     # We're allowing this for serialization.
     contains(markers[:filename], "src/Database") && return


### PR DESCRIPTION
Packaging currently underway. Once that's done, we can remove the `src/FrontCompiler` bit.