### PR TITLE
`@generated` is now fatal

### DIFF
--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -328,7 +328,7 @@ struct SleepRule <: RecommendationLintRule end
 struct InboundsRule <: RecommendationLintRule end
 struct ArrayWithNoTypeRule <: ViolationLintRule end
 struct ThreadsRule <: RecommendationLintRule end
-struct GeneratedRule <: RecommendationLintRule end
+struct GeneratedRule <: FatalLintRule end
 struct SyncRule <: RecommendationLintRule end
 struct RemovePageRule <: ViolationLintRule end
 struct TaskRule <: ViolationLintRule end


### PR DESCRIPTION
As described [HERE](https://relationalai.slack.com/archives/C01T759CHGF/p1758055343692399?thread_ts=1757473240.916789&cid=C01T759CHGF)