### PR TITLE
Disable ReturnTypeAnnotationRule

### DIFF
--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -362,7 +362,8 @@ struct NotImportingRAICodeRule <: ViolationLintRule end
 struct BareUsingRule <: ViolationLintRule end
 struct UntypedArrayComprehensionRule <: ViolationLintRule end
 # TODO: The RAI Style Guide recommends against return type annotations, but this rule
-# is not currently enforced. See: https://github.com/RelationalAI/RAIStyle#type-annotations
+# is not currently enforced. See: https://github.com/RelationalAI/RAIStyle#type-annotations (There was previously a rule for this, but
+# it was removed in PR #75.)
 struct StringConcatenationRule <: RecommendationLintRule end
 struct NoGlobalVariablesRule <: RecommendationLintRule end
 struct ConstGlobalMissingTypeRule <: ViolationLintRule end

--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -361,7 +361,7 @@ struct NoImportRule <: ViolationLintRule end
 struct NotImportingRAICodeRule <: ViolationLintRule end
 struct BareUsingRule <: ViolationLintRule end
 struct UntypedArrayComprehensionRule <: ViolationLintRule end
-struct ReturnTypeAnnotationRule <: RecommendationLintRule end
+# Disabled: struct ReturnTypeAnnotationRule <: RecommendationLintRule end
 struct StringConcatenationRule <: RecommendationLintRule end
 struct NoGlobalVariablesRule <: RecommendationLintRule end
 struct ConstGlobalMissingTypeRule <: ViolationLintRule end
@@ -883,21 +883,22 @@ function check(t::UntypedArrayComprehensionRule, x::EXPR, markers::Dict{Symbol,S
     generic_check(t, x, "[hole_variable for hole_variable in hole_variable]", msg)
 end
 
-function check(t::ReturnTypeAnnotationRule, x::EXPR, markers::Dict{Symbol,String})
-    # Skip test files
-    if haskey(markers, :filename)
-        contains(markers[:filename], "test/") && return
-        contains(markers[:filename], "test.jl") && return
-    end
-
-    msg = "Avoid return type annotations `function foo()::Type`. Return type annotations can hurt performance by forcing type conversions. [Explanation](https://github.com/RelationalAI/RAIStyle?tab=readme-ov-file#type-annotations)."
-
-    # Pattern: function name()::Type ... end (multiline)
-    generic_check(t, x, "function hole_variable(hole_variable_star)::hole_variable hole_variable_star end", msg)
-
-    # Pattern: name()::Type = ... (one-liner)
-    generic_check(t, x, "hole_variable(hole_variable_star)::hole_variable = hole_variable", msg)
-end
+# Disabled: ReturnTypeAnnotationRule
+# function check(t::ReturnTypeAnnotationRule, x::EXPR, markers::Dict{Symbol,String})
+#     # Skip test files
+#     if haskey(markers, :filename)
+#         contains(markers[:filename], "test/") && return
+#         contains(markers[:filename], "test.jl") && return
+#     end
+#
+#     msg = "Avoid return type annotations `function foo()::Type`. Return type annotations can hurt performance by forcing type conversions. [Explanation](https://github.com/RelationalAI/RAIStyle?tab=readme-ov-file#type-annotations)."
+#
+#     # Pattern: function name()::Type ... end (multiline)
+#     generic_check(t, x, "function hole_variable(hole_variable_star)::hole_variable hole_variable_star end", msg)
+#
+#     # Pattern: name()::Type = ... (one-liner)
+#     generic_check(t, x, "hole_variable(hole_variable_star)::hole_variable = hole_variable", msg)
+# end
 
 function check(t::StringConcatenationRule, x::EXPR, markers::Dict{Symbol,String})
     # Skip test files

--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -361,7 +361,8 @@ struct NoImportRule <: ViolationLintRule end
 struct NotImportingRAICodeRule <: ViolationLintRule end
 struct BareUsingRule <: ViolationLintRule end
 struct UntypedArrayComprehensionRule <: ViolationLintRule end
-# Disabled: struct ReturnTypeAnnotationRule <: RecommendationLintRule end
+# TODO: The RAI Style Guide recommends against return type annotations, but this rule
+# is not currently enforced. See: https://github.com/RelationalAI/RAIStyle#type-annotations
 struct StringConcatenationRule <: RecommendationLintRule end
 struct NoGlobalVariablesRule <: RecommendationLintRule end
 struct ConstGlobalMissingTypeRule <: ViolationLintRule end
@@ -882,23 +883,6 @@ function check(t::UntypedArrayComprehensionRule, x::EXPR, markers::Dict{Symbol,S
     # This catches [x for x in xs] but not T[x for x in xs]
     generic_check(t, x, "[hole_variable for hole_variable in hole_variable]", msg)
 end
-
-# Disabled: ReturnTypeAnnotationRule
-# function check(t::ReturnTypeAnnotationRule, x::EXPR, markers::Dict{Symbol,String})
-#     # Skip test files
-#     if haskey(markers, :filename)
-#         contains(markers[:filename], "test/") && return
-#         contains(markers[:filename], "test.jl") && return
-#     end
-#
-#     msg = "Avoid return type annotations `function foo()::Type`. Return type annotations can hurt performance by forcing type conversions. [Explanation](https://github.com/RelationalAI/RAIStyle?tab=readme-ov-file#type-annotations)."
-#
-#     # Pattern: function name()::Type ... end (multiline)
-#     generic_check(t, x, "function hole_variable(hole_variable_star)::hole_variable hole_variable_star end", msg)
-#
-#     # Pattern: name()::Type = ... (one-liner)
-#     generic_check(t, x, "hole_variable(hole_variable_star)::hole_variable = hole_variable", msg)
-# end
 
 function check(t::StringConcatenationRule, x::EXPR, markers::Dict{Symbol,String})
     # Skip test files

--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -361,7 +361,7 @@ struct NoImportRule <: ViolationLintRule end
 struct NotImportingRAICodeRule <: ViolationLintRule end
 struct BareUsingRule <: ViolationLintRule end
 struct UntypedArrayComprehensionRule <: ViolationLintRule end
-# TODO(RAI-95949): Enforce the style guide's recommendation against return type annotations.
+# TODO(RAI-45949): Enforce the style guide's recommendation against return type annotations.
 # First we need `@assert_returntype`, as suggested in the style guide.
 # See: https://github.com/RelationalAI/RAIStyle#type-annotations
 # (There was previously a rule for this, but it was removed in PR #75.)

--- a/src/linting/extended_checks.jl
+++ b/src/linting/extended_checks.jl
@@ -361,9 +361,10 @@ struct NoImportRule <: ViolationLintRule end
 struct NotImportingRAICodeRule <: ViolationLintRule end
 struct BareUsingRule <: ViolationLintRule end
 struct UntypedArrayComprehensionRule <: ViolationLintRule end
-# TODO: The RAI Style Guide recommends against return type annotations, but this rule
-# is not currently enforced. See: https://github.com/RelationalAI/RAIStyle#type-annotations (There was previously a rule for this, but
-# it was removed in PR #75.)
+# TODO(RAI-95949): Enforce the style guide's recommendation against return type annotations.
+# First we need `@assert_returntype`, as suggested in the style guide.
+# See: https://github.com/RelationalAI/RAIStyle#type-annotations
+# (There was previously a rule for this, but it was removed in PR #75.)
 struct StringConcatenationRule <: RecommendationLintRule end
 struct NoGlobalVariablesRule <: RecommendationLintRule end
 struct ConstGlobalMissingTypeRule <: ViolationLintRule end

--- a/test/rai_rules_tests.jl
+++ b/test/rai_rules_tests.jl
@@ -2040,10 +2040,10 @@ end
     end
 end
 
-# TODO: The RAI Style Guide recommends against return type annotations, but this rule
-# is not currently enforced. Add tests here when the rule is re-enabled.
-# See: https://github.com/RelationalAI/RAIStyle#type-annotations (There was previously
-# a rule for this, but it was removed in PR #75.)
+# TODO(RAI-95949): Enforce the style guide's recommendation against return type annotations.
+# First we need `@assert_returntype`, as suggested in the style guide.
+# See: https://github.com/RelationalAI/RAIStyle#type-annotations
+# (There was previously a rule for this, but it was removed in PR #75.)
 
 @testset "String concatenation with *" begin
     @testset "string literal concatenation" begin

--- a/test/rai_rules_tests.jl
+++ b/test/rai_rules_tests.jl
@@ -2042,7 +2042,8 @@ end
 
 # TODO: The RAI Style Guide recommends against return type annotations, but this rule
 # is not currently enforced. Add tests here when the rule is re-enabled.
-# See: https://github.com/RelationalAI/RAIStyle#type-annotations
+# See: https://github.com/RelationalAI/RAIStyle#type-annotations (There was previously
+# a rule for this, but it was removed in PR #75.)
 
 @testset "String concatenation with *" begin
     @testset "string literal concatenation" begin

--- a/test/rai_rules_tests.jl
+++ b/test/rai_rules_tests.jl
@@ -2040,57 +2040,58 @@ end
     end
 end
 
-@testset "Return type annotations" begin
-    @testset "function with return type annotation" begin
-        source = """
-            function foo(x::Int)::String
-                return string(x)
-            end
-            """
-        @test lint_has_error_test(source)
-        @test lint_test(source,
-            "Line 1, column 1: Avoid return type annotations")
-    end
-
-    @testset "function without return type annotation is ok" begin
-        source = """
-            function foo(x::Int)
-                return string(x)
-            end
-            """
-        @test !lint_has_error_test(source)
-    end
-
-    @testset "multiple functions with annotations" begin
-        source = """
-            function foo(x::Int)::String
-                return string(x)
-            end
-
-            function bar(y::Float64)::Int
-                return round(Int, y)
-            end
-
-            function baz(z)
-                return z + 1
-            end
-            """
-        @test count_lint_errors(source) == 2
-        @test lint_test(source,
-            "Line 1, column 1: Avoid return type annotations")
-        @test lint_test(source,
-            "Line 5, column 1: Avoid return type annotations")
-    end
-
-    @testset "one-liner with return type" begin
-        source = """
-            foo(x::Int)::String = string(x)
-            """
-        @test lint_has_error_test(source)
-        @test lint_test(source,
-            "Line 1, column 1: Avoid return type annotations")
-    end
-end
+# Disabled: ReturnTypeAnnotationRule tests
+# @testset "Return type annotations" begin
+#     @testset "function with return type annotation" begin
+#         source = """
+#             function foo(x::Int)::String
+#                 return string(x)
+#             end
+#             """
+#         @test lint_has_error_test(source)
+#         @test lint_test(source,
+#             "Line 1, column 1: Avoid return type annotations")
+#     end
+#
+#     @testset "function without return type annotation is ok" begin
+#         source = """
+#             function foo(x::Int)
+#                 return string(x)
+#             end
+#             """
+#         @test !lint_has_error_test(source)
+#     end
+#
+#     @testset "multiple functions with annotations" begin
+#         source = """
+#             function foo(x::Int)::String
+#                 return string(x)
+#             end
+#
+#             function bar(y::Float64)::Int
+#                 return round(Int, y)
+#             end
+#
+#             function baz(z)
+#                 return z + 1
+#             end
+#             """
+#         @test count_lint_errors(source) == 2
+#         @test lint_test(source,
+#             "Line 1, column 1: Avoid return type annotations")
+#         @test lint_test(source,
+#             "Line 5, column 1: Avoid return type annotations")
+#     end
+#
+#     @testset "one-liner with return type" begin
+#         source = """
+#             foo(x::Int)::String = string(x)
+#             """
+#         @test lint_has_error_test(source)
+#         @test lint_test(source,
+#             "Line 1, column 1: Avoid return type annotations")
+#     end
+# end
 
 @testset "String concatenation with *" begin
     @testset "string literal concatenation" begin

--- a/test/rai_rules_tests.jl
+++ b/test/rai_rules_tests.jl
@@ -2040,58 +2040,9 @@ end
     end
 end
 
-# Disabled: ReturnTypeAnnotationRule tests
-# @testset "Return type annotations" begin
-#     @testset "function with return type annotation" begin
-#         source = """
-#             function foo(x::Int)::String
-#                 return string(x)
-#             end
-#             """
-#         @test lint_has_error_test(source)
-#         @test lint_test(source,
-#             "Line 1, column 1: Avoid return type annotations")
-#     end
-#
-#     @testset "function without return type annotation is ok" begin
-#         source = """
-#             function foo(x::Int)
-#                 return string(x)
-#             end
-#             """
-#         @test !lint_has_error_test(source)
-#     end
-#
-#     @testset "multiple functions with annotations" begin
-#         source = """
-#             function foo(x::Int)::String
-#                 return string(x)
-#             end
-#
-#             function bar(y::Float64)::Int
-#                 return round(Int, y)
-#             end
-#
-#             function baz(z)
-#                 return z + 1
-#             end
-#             """
-#         @test count_lint_errors(source) == 2
-#         @test lint_test(source,
-#             "Line 1, column 1: Avoid return type annotations")
-#         @test lint_test(source,
-#             "Line 5, column 1: Avoid return type annotations")
-#     end
-#
-#     @testset "one-liner with return type" begin
-#         source = """
-#             foo(x::Int)::String = string(x)
-#             """
-#         @test lint_has_error_test(source)
-#         @test lint_test(source,
-#             "Line 1, column 1: Avoid return type annotations")
-#     end
-# end
+# TODO: The RAI Style Guide recommends against return type annotations, but this rule
+# is not currently enforced. Add tests here when the rule is re-enabled.
+# See: https://github.com/RelationalAI/RAIStyle#type-annotations
 
 @testset "String concatenation with *" begin
     @testset "string literal concatenation" begin


### PR DESCRIPTION
The return type annotation check needs more consideration before enabling.

