### PR TITLE
Minor fixes

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -248,7 +248,7 @@ lint_file(rootpath, context::LintContext=LintContext()) =
 Runs lint checks on `text`. Lints will be reported as comming from `filename`.
 """
 function lint_text(text::String; filename="<string>", context::LintContext=LintContext())
-    ast = JuliaSyntax.parseall(SyntaxNode, text; filename=filename)
+    ast = JuliaSyntax.parseall(SyntaxNode, text; filename=filename, ignore_warnings=true)
     ast = Argus._normalise!(ast)
 
     lint_rule_reports = []

--- a/src/rules/fatal.jl
+++ b/src/rules/fatal.jl
@@ -230,8 +230,9 @@ register_syntax_class!(:do_call_with_return, SyntaxClass(
              @when [:f] begin
                  isempty(f.args.src) && return false
                  do_node = f.args.src[end]
-                 return kind(do_node) == K"do" &&
-                     kind(do_node.children[2].children[end]) == K"return"
+                 kind(do_node) == K"do" || return false
+                 isempty(do_node.children[2].children) && return false
+                 return kind(do_node.children[2].children[end]) == K"return"
              end
          end),
         (@pattern begin
@@ -239,8 +240,9 @@ register_syntax_class!(:do_call_with_return, SyntaxClass(
              @when [:m] begin
                  isempty(m.args) && return false
                  do_node = m.args[end]
-                 return kind(do_node) == K"do" &&
-                     kind(do_node.children[2].children[end]) == K"return"
+                 kind(do_node) == K"do" || return false
+                 isempty(do_node.children[2].children) && return false
+                 return kind(do_node.children[2].children[end]) == K"return"
              end
          end)
     ]


### PR DESCRIPTION
- The `do_call_with_return` syntax class defined for `"return in anonymous function"` didn't cover the case of an empty `do` block.
- Parsing source code should ignore warnings when linting.